### PR TITLE
Fix #2

### DIFF
--- a/lib/slimtimercli/helper.rb
+++ b/lib/slimtimercli/helper.rb
@@ -1,7 +1,7 @@
 module Slimtimercli
   module Helper
     def login
-      config = Helper::load_config
+      config = load_config
       st = SlimTimer.new(config["email"], config["password"],
         config["api_key"])
       st.login


### PR DESCRIPTION
Referring to Helper:: explicilty in login, which was defined before
load_config, caused an error. Removing the explicit namespacing solved
the issue.
